### PR TITLE
Prevent leave request submission with empty leave type (#547)

### DIFF
--- a/public/js/global.js
+++ b/public/js/global.js
@@ -280,10 +280,19 @@ $(document).ready(function() {
  */
  $(document).ready(function(){
   $('.single-click').on('click', function(e) {
-    e.stopPropagation();
+    var form = $(e.target).closest('form');
+
+    // Ensure "required" fields are populated
+    var formIsValid = true;
+    $(form).find('[required]').each(function(el){formIsValid = formIsValid && !! el.val()});
+    if (formIsValid) {
+      e.stopPropagation();
+    } else {
+      return;
+    }
 
     $(e.target).prop('disabled', true);
-    var form = $(e.target).closest('form');
+
     var submitName = $(e.target).attr('name');
     if (submitName !== undefined) {
       $('<input>').attr({type: 'hidden', name: submitName, value: '1'}).appendTo(form);

--- a/t/integration/leave_request/leave_request_revoke.js
+++ b/t/integration/leave_request/leave_request_revoke.js
@@ -186,10 +186,10 @@ describe('Revoke leave request', function(){
             value           : "2",
           },{
             selector : 'input#from',
-            value : `${currentYear}-05-12`,
+            value : `${currentYear}-05-11`,
           },{
             selector : 'input#to',
-            value : `${currentYear}-05-13`,
+            value : `${currentYear}-05-12`,
           }],
           message : /New leave request was added/,
         })
@@ -200,8 +200,8 @@ describe('Revoke leave request', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment.utc(`${currentYear}-05-13`)],
-      halfs_1st_days : [moment.utc(`${currentYear}-05-12`)],
+      full_days      : [moment.utc(`${currentYear}-05-12`)],
+      halfs_1st_days : [moment.utc(`${currentYear}-05-11`)],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_request/leave_request_revoke_by_admin.js
+++ b/t/integration/leave_request/leave_request_revoke_by_admin.js
@@ -114,10 +114,10 @@ describe('Revoke leave request by Admin', function(){
             value           : "2",
           },{
             selector : 'input#from',
-            value : `${currentYear}-05-12`,
+            value : `${currentYear}-05-11`,
           },{
             selector : 'input#to',
-            value : `${currentYear}-05-13`,
+            value : `${currentYear}-05-12`,
           }],
           message : /New leave request was added/,
         })
@@ -128,8 +128,8 @@ describe('Revoke leave request by Admin', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment.utc(`${currentYear}-05-13`)],
-      halfs_1st_days : [moment.utc(`${currentYear}-05-12`)],
+      full_days      : [moment.utc(`${currentYear}-05-12`)],
+      halfs_1st_days : [moment.utc(`${currentYear}-05-11`)],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_type/leave_type_limit_next_year.js
+++ b/t/integration/leave_type/leave_type_limit_next_year.js
@@ -115,10 +115,10 @@ describe('Leave type limits for next year: ' + next_year, function(){
           driver      : driver,
           form_params : [{
             selector : 'input#from',
-            value : next_year + '-05-11',
+            value : next_year + '-05-10',
           },{
             selector : 'input#to',
-            value : next_year + '-05-11',
+            value : next_year + '-05-10',
           }],
           message : /New leave request was added/,
         })
@@ -126,7 +126,7 @@ describe('Leave type limits for next year: ' + next_year, function(){
         .then(function(){
           check_booking_func({
             driver    : driver,
-            full_days : [moment(next_year + '-05-11')],
+            full_days : [moment(next_year + '-05-10')],
             type      : 'pended',
           })
           .then(function(){ done() });

--- a/views/partials/book_leave_modal.hbs
+++ b/views/partials/book_leave_modal.hbs
@@ -22,7 +22,7 @@
 
           <div class="form-group">
             <label for="leave_type" class="control-label">Leave type:</label>
-            <select class="form-control" id="leave_type" name="leave_type">
+            <select class="form-control" id="leave_type" name="leave_type" required>
             {{# is_force_to_explicitly_select_type_when_requesting_new_leave}}
               <option disabled selected value>-- select an option --</option>
             {{/ is_force_to_explicitly_select_type_when_requesting_new_leave}}


### PR DESCRIPTION
* Ensure it is impossible to submit leave form with empty type

* Update the tests for new year

Co-authored-by: Pavlo <pavlo@>